### PR TITLE
Add option for generating whitespace tokens

### DIFF
--- a/JsonTokenizer.js
+++ b/JsonTokenizer.js
@@ -1,6 +1,6 @@
 var Tokenizer = require('tokenizer');
 
-module.exports = function JsonTokenizer() {
+module.exports = function JsonTokenizer(options) {
     var t = new Tokenizer();
     
     t.addRule(/^,$/, 'comma');
@@ -24,7 +24,9 @@ module.exports = function JsonTokenizer() {
     t.addRule(/^\w+$/, 'symbol');
 
     t.addRule(Tokenizer.whitespace);
-    t.ignore('whitespace');
+    if (options == null || !options.whitespace) {
+        t.ignore('whitespace');
+    }
     // if we had comments tokens, we would ignore them as well
     // but the JSON spec doesn't allow comments!
     

--- a/README.markdown
+++ b/README.markdown
@@ -38,6 +38,24 @@ t.end('[8, {}]');
 
 more usually you have a readable stream with a json document that you pipe to this.
 
+## Interface
+
+```javascript
+var tokenizer = require('json-tokenizer');
+var t = tokenizer();
+```
+
+The module exports a single function, which returns a [Tokenizer](https://github.com/Floby/node-tokenizer) stream.
+
+```javascript
+var tokenizer = require('json-tokenizer');
+var t = tokenizer({'whitespace': true});
+```
+
+The function optionally takes an `options` object as a parameter:
+
+* `whitespace`: If `true`, create `whitespace` tokens in the output stream. Defaults to `false`.
+
 ## License
 
 [MIT](http://opensource.org/licenses/MIT)

--- a/test/test-whitespace.js
+++ b/test/test-whitespace.js
@@ -1,0 +1,47 @@
+var tokenizer = require('../');
+var sink = require('stream-sink');
+
+exports['test whitespace default behavior'] = function (test) {
+  var input = ' \n ';
+  var t = tokenizer();
+  t.pipe(sink({objectMode: true})).on('data', function (tokens) {
+    test.equal(0, tokens.length, 'There should be no tokens');
+    test.done();
+  });
+
+  t.end(input);
+}
+
+exports['test simple whitespace'] = function (test) {
+  var input = ' \n ';
+  var t = tokenizer({whitespace: true});
+  t.pipe(sink({objectMode: true})).on('data', function (tokens) {
+    test.equal(1, tokens.length, 'There should be only one token');
+    test.equal(' \n ', tokens[0].content);
+    test.equal('whitespace', tokens[0].type, 'token should be of type whitespace');
+    test.equal(input, tokens[0].toString());
+    test.done();
+  });
+
+  t.end(input);
+}
+
+exports['test whitespace with other tokens'] = function (test) {
+  var input = '["I am",  "a string"]';
+  var t = tokenizer({whitespace: true});
+  t.pipe(sink({objectMode: true})).on('data', function (tokens) {
+    test.equal(6, tokens.length, 'There should be six tokens');
+    test.equal('  ', tokens[3].content);
+    test.equal('whitespace', tokens[3].type, 'space token should be of type whitespace');
+    test.equal('  ', tokens[3].toString(), 'token should stringify back to two spaces');
+
+    var reconstructedInput = tokens.map(function(token){
+      return token.toString();
+    }).join('');
+    test.equal(input, reconstructedInput, 'input roundtrips through tokenizer');
+
+    test.done();
+  });
+
+  t.end(input);
+}


### PR DESCRIPTION
Hi! I'm writing a JSON colorizer, and json-tokenizer does almost exactly what I need, except that it ignores whitespace tokens, which I need in my output stream to preserve document formatting.

This PR adds an optional `options` object as an argument to `tokenize()`, which has a boolean `whitespace` property. If true, whitespace tokens are not ignored.

In particular, please let me know if
- you'd like me to organize the documentation differently
- there are any coding style changes you'd like me to make
- you would prefer a different way of turning this feature on

Thanks so much!
